### PR TITLE
Break off separate `chunktool`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ This command will load each rule group in the specified files and load them into
 
     cortextool rules load ./example_rules_one.yaml ./example_rules_two.yaml  ...
 
-## Chunks
+# chunktool
+
+This repo also contains the `chunktool`. I client meant to interact with chunks stored and indexed in cortex backends.
 
 ### Chunk Delete
 

--- a/cmd/chunktool/Dockerfile
+++ b/cmd/chunktool/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.12.5-stretch as build
+ARG GOARCH="amd64"
+COPY . /build_dir
+WORKDIR /build_dir
+ENV GOPROXY=https://proxy.golang.org
+RUN make clean && make chunktool
+
+FROM       alpine:3.9
+RUN        apk add --update --no-cache ca-certificates
+COPY       --from=build /build_dir/cmd/chunktool/chunktool /usr/bin/chunktool
+EXPOSE     80
+ENTRYPOINT [ "/usr/bin/chunktool" ]

--- a/cmd/chunktool/main.go
+++ b/cmd/chunktool/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"os"
+
+	"github.com/grafana/cortextool/pkg/commands"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	logConfig   commands.LoggerConfig
+	pushGateway commands.PushGatewayConfig
+)
+
+func main() {
+	kingpin.Version("0.0.1")
+	app := kingpin.New("cortextool", "A command-line tool to manage cortex chunk backends.")
+	logConfig.Register(app)
+	commands.RegisterChunkCommands(app)
+	pushGateway.Register(app)
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+
+	pushGateway.Stop()
+}

--- a/cmd/cortextool/main.go
+++ b/cmd/cortextool/main.go
@@ -15,10 +15,9 @@ var (
 )
 
 func main() {
-	kingpin.Version("0.0.1")
+	kingpin.Version("0.1.3")
 	app := kingpin.New("cortextool", "A command-line tool to manage cortex.")
 	logConfig.Register(app)
-	commands.RegisterChunkCommands(app)
 	alertCommand.Register(app)
 	ruleCommand.Register(app)
 	pushGateway.Register(app)


### PR DESCRIPTION
Currently the `chunktool` does not seem relevant to the `cortextool` since one acts directly on the cortex API and the other works directly with the data backends. This PR breaks them off into separate tools.

Signed-off-by: Jacob Lisi <jacob.t.lisi@gmail.com>